### PR TITLE
🐛 revise format of metrics summaries & add tests

### DIFF
--- a/src/emcommon/metrics/metrics_summaries.py
+++ b/src/emcommon/metrics/metrics_summaries.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # __: skip
 # from util import memoize
+import time
 import emcommon.logger as Log
 import emcommon.util as util
 import emcommon.bluetooth.ble_matching as emcble
@@ -22,10 +23,11 @@ async def generate_summaries(
     _labels_map: dict[str, any] = None,
 ) -> dict[str, list[dict[str, any]]]:
     """
-    :param metric_list: dict of metric names to lists of grouping fields, e.g. { 'distance': ['mode_confirm', 'purpose_confirm'] }
+    :param metric_list: dict of metric names to lists of dimensions, e.g. { 'distance': ['mode_confirm', 'purpose_confirm'] }
     :param trips: list of trips, which may be either confirmed_trips or composite_trips
     :param _app_config: app_config, or partial app_config with 'survey_info' present
     :param _labels_map: map of trip_ids to unprocessed user input labels
+    :return: a list of dicts, each representing a summary of a metric on one day
     """
     global app_config, labels_map
     app_config = _app_config
@@ -48,13 +50,14 @@ async def generate_summaries(
     confirmed_trips.sort(key=lambda trip: trip['start_ts'])
 
     metric_list = dict(metric_list)
-    summaries = {}
+    summaries = []
     for metric in metric_list.items():
-        summaries[metric[0]] = await get_summary_for_metric(metric, confirmed_trips)
+        summaries_for_metric = await get_summary_for_metric(metric, confirmed_trips)
+        summaries.extend(summaries_for_metric)
     return summaries
 
 
-async def value_of_metric_for_trip(metric_name: str, grouping_field: str, grouping_val: str, trip: dict):
+async def value_of_metric_for_trip(metric_name: str, dimension: str, dimension_val: str, trip: dict):
     global app_config, labels_map
     if metric_name == 'distance':
         return trip['distance']
@@ -63,19 +66,19 @@ async def value_of_metric_for_trip(metric_name: str, grouping_field: str, groupi
     elif metric_name == 'duration':
         return trip['duration']
     elif metric_name == 'response_count':
-        if grouping_field == 'survey':
+        if dimension == 'survey':
             prompted_survey = emcsc.survey_prompted_for_trip(trip, app_config)
             answered_survey = emcdu.survey_answered_for_trip(trip, labels_map)
             return 'responded' if answered_survey == prompted_survey else 'not_responded'
         else:
-            if grouping_val == 'UNKNOWN' or grouping_val == 'UNLABELED':
+            if dimension_val == 'UNKNOWN' or dimension_val == 'UNLABELED':
                 return 'not_responded'
             return 'responded'
     elif metric_name == 'footprint':
         (footprint, metadata) = await emcmff.calc_footprint_for_trip(trip,
                                                                      app_config['label_options'],
                                                                      'mode',
-                                                                     grouping_val,
+                                                                     dimension_val,
                                                                      labels_map)
         footprint.update({'metadata': metadata})
         return footprint
@@ -105,11 +108,20 @@ def acc_value_of_metric(metric_name: str, acc, new_val):
 
 async def get_summary_for_metric(metric: tuple[str, list[str]], confirmed_trips: list):
     """
-    :param metric: tuple of metric name and list of grouping fields
+    :param metric: tuple of metric name and list of dimensions
     :param confirmed_trips: list of confirmed trips
     :return: a list of dicts, each representing a summary of the metric on one day
-    e.g. get_summary_for_metric(('distance', ['mode_confirm', 'purpose_confirm']), confirmed_trips)
-      -> [ { 'date': '2024-05-20', 'mode_confirm_bike': 1000, 'mode_confirm_walk': 500, 'purpose_confirm_home': 1500 } ]
+        e.g. get_summary_for_metric(('distance', ['mode_confirm', 'purpose_confirm']), confirmed_trips) 
+        [{
+            'date': '2024-05-20',
+            'metric': 'distance',
+            'nUsers': 2,
+            'dimensions': {
+                'mode_confirm': { 'value': 'bike', 'measure': 1000 },
+                'purpose_confirm': { 'value': 'home', 'measure': 1500 }
+            },
+            'last_updated': 1747155305,
+        }]
     """
     days_of_metrics_data = {}
     for trip in confirmed_trips:
@@ -118,19 +130,20 @@ async def get_summary_for_metric(metric: tuple[str, list[str]], confirmed_trips:
         if date not in days_of_metrics_data:
             days_of_metrics_data[date] = []
         days_of_metrics_data[date].append(trip)
-    # days_summaries e.g. [ { 'date': '2024-05-20', 'mode_confirm_bike': 1000, 'purpose_confirm_home': 1500 } ]
     days_summaries = []
     for date, trips in days_of_metrics_data.items():
         summary_for_day = {
             'date': date,
+            'metric': metric[0],
             'nUsers': len({o['user_id']: 1 for o in trips}),
+            'dimensions': await metric_dimensions_for_trips(metric, trips),
+            'last_updated': int(time.time()),
         }
-        summary_for_day.update(await metric_summary_for_trips(metric, trips))
         days_summaries.append(summary_for_day)
     return days_summaries
 
 
-grouping_field_fns = {
+dimensions_fns = {
     'mode_confirm': lambda trip: emcdu.label_for_trip(trip, 'mode', labels_map) or 'UNLABELED',
     'purpose_confirm': lambda trip: emcdu.label_for_trip(trip, 'purpose', labels_map) or 'UNLABELED',
     'replaced_mode_confirm': lambda trip: emcdu.label_for_trip(trip, 'replaced_mode', labels_map) or 'UNLABELED',
@@ -141,34 +154,69 @@ grouping_field_fns = {
 }
 
 
-async def metric_summary_for_trips(metric: tuple[str, list[str]], confirmed_trips: list):
+async def metric_dimensions_for_trips(metric: tuple[str, list[str]], confirmed_trips: list):
     """
-    :param metric: tuple of metric name and list of grouping fields
+    :param metric: tuple of metric name and list of dimensions
     :param confirmed_trips: list of confirmed trips
-    :return: a dict of { groupingfield_value : metric_total } for the given metric and trips
-    e.g. metric_summary_for_trips(('distance', ['mode_confirm', 'purpose_confirm']), confirmed_trips)
+    :return: a dict of { dimension: [ { "value": "foo", "measure": 0 } ] } for the given metric and trips
+    e.g. metric_dimensions_for_trips(('distance', ['mode_confirm', 'purpose_confirm']), confirmed_trips)
       -> { 'mode_confirm_bike': 1000, 'mode_confirm_walk': 500, 'purpose_confirm_home': 1500 }
-    e.g. metric_summary_for_trips(('response_count', ['mode_confirm', 'purpose_confirm']), confirmed_trips)
+    e.g. metric_dimensions_for_trips(('response_count', ['mode_confirm', 'purpose_confirm']), confirmed_trips)
       -> { 'mode_confirm_bike': { 'responded': 10, 'not_responded': 5 }, 'mode_confirm_walk': { 'responded': 5, 'not_responded': 10 } }
     """
     global app_config
-    groups = {}
+    dimensions = {}
     if not confirmed_trips:
-        return groups
+        return dimensions
     for trip in confirmed_trips:
         if 'primary_ble_sensed_mode' not in trip:
             trip['primary_ble_sensed_mode'] = emcble.primary_ble_sensed_mode_for_trip(
                 trip) or 'UNKNOWN'
-        for grouping_field in metric[1]:
-            if grouping_field not in grouping_field_fns:
+        for dimension in metric[1]:
+            if dimension not in dimensions_fns:
                 continue
-            field_value_for_trip = grouping_field_fns[grouping_field](trip)
-            if field_value_for_trip is None:
+            dimension_value_for_trip = dimensions_fns[dimension](trip)
+            if dimension_value_for_trip is None:
                 continue
-            # grouping_key e.g. 'mode_confirm_bike'
-            grouping_key = grouping_field + '_' + field_value_for_trip
-            val = await value_of_metric_for_trip(metric[0], grouping_field, field_value_for_trip, trip)
-            groups[grouping_key] = acc_value_of_metric(metric[0],
-                                                       groups.get(grouping_key),
-                                                       val)
-    return groups
+            if dimension not in dimensions:
+                dimensions[dimension] = []
+
+            existing = None
+            for d in dimensions[dimension]:
+                if d['value'] == dimension_value_for_trip:
+                    existing = d
+                    break
+            measure_for_trip = await value_of_metric_for_trip(metric[0], dimension, dimension_value_for_trip, trip)
+            measure = acc_value_of_metric(metric[0],
+                                          existing['measure'] if existing else None,
+                                          measure_for_trip)
+            if existing is None:
+                dimensions[dimension].append({
+                    'value': dimension_value_for_trip,
+                    'measure': measure
+                })
+            else:
+                existing['measure'] = measure
+    return dimensions
+
+
+def munge_agg_metrics(metrics_days):
+    """
+    Backwards compat to get summaries into the old format that the phone expects in May 2025
+    After phone changes and waiting a few months, we can remove this
+    """
+    munged_result = {}
+    for metric_day in metrics_days:
+        metric = metric_day['metric']
+        if metric not in munged_result:
+            munged_result[metric] = []
+        munged_summary = {
+            'date': metric_day['date'],
+            'nUsers': metric_day['nUsers'],
+        }
+        print(f"metric_day: {metric_day}")
+        for dimension in metric_day['dimensions'].keys():
+            for dimension_value in metric_day['dimensions'][dimension]:
+                munged_summary[f"{dimension}_{dimension_value['value']}"] = dimension_value['measure']
+        munged_result[metric].append(munged_summary)
+    return munged_result

--- a/test/metrics/test_metrics_summaries.py
+++ b/test/metrics/test_metrics_summaries.py
@@ -1,0 +1,78 @@
+import time
+import emcommon.metrics.metrics_summaries as emcmms
+from ..__testing import jest_test, jest_describe, expectEqual, expectAlmostEqual
+
+
+def fake_trip(user_id, date, distance, mode, purpose):
+    return {
+        "_id": 'fake_trip_id',
+        "user_id": user_id,
+        "key": 'analysis/confirmed_trip',
+        "distance": distance,
+        "start_ts": date * 86400,
+        "start_fmt_time": f'1970-01-0{date}T00:00:00',
+        "start_loc": {"coordinates": [0, 0]},
+        "user_input": {"mode_confirm": mode, "purpose_confirm": purpose}
+    }
+
+
+metric_list = {'distance': ['mode_confirm', 'purpose_confirm']}
+fake_trips = [
+    fake_trip('user_id_1', 1, 1000, 'e-car', 'home'),
+    fake_trip('user_id_2', 1, 1000, 'e-car', 'meal'),
+    fake_trip('user_id_1', 2, 2500, 'e-car', 'work'),
+    fake_trip('user_id_2', 2, 500, 'bike', 'work'),
+]
+
+
+@jest_test
+async def test_distance_metrics():
+    summaries = await emcmms.generate_summaries(metric_list, fake_trips, {}, {})
+    generated_time = time.time()
+
+    day1_distance = next(d for d in summaries if d['date'] == '1970-01-01')
+    expectEqual(day1_distance['metric'], 'distance')
+    expectEqual(day1_distance['nUsers'], 2)
+    expectAlmostEqual(day1_distance['last_updated'] / 1000, generated_time / 1000, places=1)
+    day0_distance_mode_confirm = day1_distance['dimensions']['mode_confirm']
+    e_car = next(d for d in day0_distance_mode_confirm if d['value'] == 'e-car')
+    expectEqual(e_car['measure'], 2000)
+    day0_distance_purpose_confirm = day1_distance['dimensions']['purpose_confirm']
+    home = next(d for d in day0_distance_purpose_confirm if d['value'] == 'home')
+    expectEqual(home['measure'], 1000)
+    meal = next(d for d in day0_distance_purpose_confirm if d['value'] == 'meal')
+    expectEqual(meal['measure'], 1000)
+
+    day2_distance = next(d for d in summaries if d['date'] == '1970-01-02')
+    expectEqual(day2_distance['metric'], 'distance')
+    expectEqual(day2_distance['nUsers'], 2)
+    expectAlmostEqual(day2_distance['last_updated'] / 1000, generated_time / 1000, places=1)
+    day1_distance_mode_confirm = day2_distance['dimensions']['mode_confirm']
+    e_car = next(d for d in day1_distance_mode_confirm if d['value'] == 'e-car')
+    expectEqual(e_car['measure'], 2500)
+    bike = next(d for d in day1_distance_mode_confirm if d['value'] == 'bike')
+    expectEqual(bike['measure'], 500)
+    day1_distance_purpose_confirm = day2_distance['dimensions']['purpose_confirm']
+    work = next(d for d in day1_distance_purpose_confirm if d['value'] == 'work')
+    expectEqual(work['measure'], 3000)
+
+
+@jest_test
+async def test_munged_distance_metrics():
+    summaries = await emcmms.generate_summaries(metric_list, fake_trips, {}, {})
+    munged_summaries = emcmms.munge_agg_metrics(summaries)
+
+    day1_distance = next(d for d in munged_summaries['distance'] if d['date'] == '1970-01-01')
+    expectEqual(day1_distance['nUsers'], 2)
+    expectEqual(day1_distance['mode_confirm_e-car'], 2000)
+    expectEqual(day1_distance['purpose_confirm_home'], 1000)
+    expectEqual(day1_distance['purpose_confirm_meal'], 1000)
+
+    day2_distance = next(d for d in munged_summaries['distance'] if d['date'] == '1970-01-02')
+    expectEqual(day2_distance['nUsers'], 2)
+    expectEqual(day2_distance['mode_confirm_e-car'], 2500)
+    expectEqual(day2_distance['mode_confirm_bike'], 500)
+    expectEqual(day2_distance['purpose_confirm_work'], 3000)
+
+
+jest_describe("test_metrics_summaries")


### PR DESCRIPTION
These are the necessary changes to switch the format of the "metrics summaries" so that the labels are never in document keys, only values – avoiding the issue where "." can appear in the key (which is not allowed by documentdb) https://github.com/e-mission/e-mission-docs/issues/1126#issuecomment-2849606586

Accordingly with this new structure, I replaced the terms "grouping field" and "grouping value" used in this code with "dimension" and "measure" (which seem to be the more standard terms)

Included a function to munge the new format into the old format

Added tests to validate both the new structure and the old structure via the munging function